### PR TITLE
WIP: [FIX] l10n_cr_edi_sale_coupon: Avoid error calculate percentage again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "costarica"]
 	path = costarica
-	url = git@git.vauxoo.com:vauxoo-dev/costarica.git
+	url = git@git.vauxoo.com:vauxoo/costarica.git
 	branch = 14.0
 [submodule "website"]
 	path = website

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "costarica"]
 	path = costarica
-	url = git@git.vauxoo.com:vauxoo/costarica.git
+	url = git@git.vauxoo.com:vauxoo-dev/costarica.git
 	branch = 14.0
 [submodule "website"]
 	path = website


### PR DESCRIPTION
Before this commit, the discount percentage was being calculate always
using the value of the fixed discount, even if the fixed discount was
actually calculated from the percentage in the first place. This made
decimal loss because the rounding to two decimals.
If the order does not have coupons or promotions it does not need to
recalculate the percentage discount, so now it doesn't.
Issue#17486